### PR TITLE
Test against the nightly build of php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+  - nightly
 
 matrix:
-    fast_finish: true
-    include:
-        - php: 5.4
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+  fast_finish: true
+  include:
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
 install:
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction


### PR DESCRIPTION
This means when the new version (7.1) is release (soon), we can have
confidence that the build will work
