### PR TITLE
Some dependencies moved to runtime for Jane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ install:
 
 script:
   - find src -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
+  - composer validate
   - test/build.sh

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "require": {
     "composer-plugin-api": "^1.0",
     "jane/open-api": "^1.2.0",
+    "jane/openapi-runtime": "^1.0",
     "nikic/php-parser": "^2.1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This will ensure that the client builds on the first run through not on
the second.
