### PR TITLE
Add 7.1 to the build list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - hhvm
+  - 7.1
   - nightly
 
 matrix:


### PR DESCRIPTION
Nightlies have now moved on to PHP 7.2. This means we're no longer
testing against PHP7.1. This adds it back in.
