### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.1
     - php: nightly
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ php:
   - 7.1
   - nightly
 
-before_install:
-  - if [ ${TRAVIS_PHP_VERSION:0:4} != "hhvm" ] && [ ${TRAVIS_PHP_VERSION:0:3} != "7.1" ]; then phpenv config-rm xdebug.ini; fi
-
 matrix:
   allow_failures:
     - php: 7.1

--- a/src/SwaggerApiInstaller.php
+++ b/src/SwaggerApiInstaller.php
@@ -82,7 +82,6 @@ class SwaggerApiInstaller extends LibraryInstaller
             return;
         }
 
-
         $directory = new RecursiveDirectoryIterator($downloadPath);
         $iterator = new RecursiveIteratorIterator(
             -$directory,


### PR DESCRIPTION
Currently PHP 7.1 is failing due to a buggy if statement in the travis config. This will fix that and make it a required version (as it has now been released)