### PR TITLE
Remove depreciated dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "purplebooth/jane-open-api-autogenerate",
-  "type": "composer-installer",
+  "type": "composer-plugin",
   "description": "This is a plugin for composer that allows you to generate a client from a given swagger definition",
   "license": "MIT",
   "keywords": ["composer", "composer-installer", "installer", "swagger", "jane", "open api"],
@@ -27,6 +27,6 @@
     }
   },
   "extra": {
-    "class": "\\PurpleBooth\\JaneOpenApiAutogenerate\\SwaggerApiInstaller"
+    "class": "\\PurpleBooth\\JaneOpenApiAutogenerate\\SwaggerApiPlugin"
   }
 }

--- a/src/SwaggerApiPlugin.php
+++ b/src/SwaggerApiPlugin.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (C) 2016 Billie Thompson
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.md file for details.
+ */
+
+namespace PurpleBooth\JaneOpenApiAutogenerate;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+/**
+ * Class SwaggerApiPlugin.
+ */
+class SwaggerApiPlugin implements PluginInterface
+{
+    /**
+     * Add the installer plugin.
+     *
+     * @param Composer    $composer
+     * @param IOInterface $io
+     */
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $installer = new SwaggerApiInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($installer);
+    }
+}


### PR DESCRIPTION
The package type 'composer-installer' is deprecated. Composer advises
that we distribute our custom installers as plugins from now on.