### PR TITLE
Minor style tweaks

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,7 +11,7 @@ coding_style:
                 linefeed_character: newline
             before_parentheses:
                 function_declaration: false
-                closure_definition: false
+                closure_definition: true
                 function_call: false
                 if: true
                 for: true


### PR DESCRIPTION
When defining a closure we should have a space before the parameters in
the function definition.